### PR TITLE
feat: strip unknown fields when validating payloads

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ module.exports = (_manifest) => {
   const rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl)
 
   const minions = manifest.workers.reduce((minionsByName, worker) => {
-    const validator = Validation(worker.validate || joi.any())
+    const validator = Validation(worker.validate || joi.any(), { stripUnknown: true })
     const handlerWithValidation = validator(worker.handler)
 
     const minion = Minion(handlerWithValidation, {


### PR DESCRIPTION
I consider this as a sane default, but ideally later we should enable the ability to override this validation options (https://github.com/pagerinc/minion-army/issues/5)