### PR TITLE
fix: make sure metadata is included after validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,15 +6,14 @@ const Jackrabbit = require('@pager/jackrabbit')
 const joi = require('@hapi/joi')
 const schema = require('./schema')
 
-const validatorFactory = (handler, schema) => (payload) => {
-
+const validatorFactory = (handler, schema) => (payload, metadata) => {
   const { error, value } = joi.validate(payload, schema, { stripUnknown: true })
 
   if (error) {
     throw error
   }
 
-  return handler(value)
+  return handler(value, metadata)
 }
 
 module.exports = (_manifest) => {

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,35 @@ test('Creates army from manifest and workers work', async t => {
   t.is(await army.minions['trueing'].handle('hola'), true)
 })
 
+test('Handlers include metadata', async t => {
+  const manifest = {
+    connection: {
+      rabbit: {
+        topic: () => ({
+          publish: () => {}
+        })
+      }
+    },
+    defaults: {
+      exchangeName: 'my-exchange-name'
+    },
+    workers: [
+      {
+        handler: (message, metadata) => ({ message, metadata }),
+        config: {
+          name: 'metaworker',
+          key: 'events.something.happened'
+        },
+        validate: joi.string()
+      }
+    ]
+  }
+
+  const army = Army(manifest)
+
+  t.deepEqual(await army.minions['metaworker'].handle('hola', 'meta'), { message: 'hola', metadata: 'meta' })
+})
+
 test('Worker handler fails validation', async t => {
   const manifest = {
     connection: {


### PR DESCRIPTION
Metadata was not being sent to handlers when doing payload validation.

Metadata provides additional useful information about received events and we were missing it!