### PR TITLE
fix: queue ready event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,10 @@ module.exports = (_manifest) => {
     const rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl);
 
     let minionsReady = manifest.workers.length;
-    const checkReady = (queue) => {
+    const checkReady = () => {
         if (--minionsReady === 0) {
-            eventEmitter.emit('ready', queue); // TODO: remove queue, would only be last
+            const workerNames = manifest.workers.map((worker) => worker.config.name);
+            eventEmitter.emit('ready', { name: workerNames.join(', ')});
         }
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,10 +36,10 @@ module.exports = (_manifest) => {
     const rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl);
 
     let minionsReady = manifest.workers.length;
-    const checkReady = () => {
+    const checkReady = (queue) => {
         if (--minionsReady === 0) {
             const workerNames = manifest.workers.map((worker) => worker.config.name);
-            eventEmitter.emit('ready', { name: workerNames.join(', ')});
+            eventEmitter.emit('ready', Object.assign(queue, { name: workerNames.join(', ')}));
         }
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,9 +36,9 @@ module.exports = (_manifest) => {
     const rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl);
 
     let minionsReady = manifest.workers.length;
-    const checkReady = () => {
+    const checkReady = (queue) => {
         if (--minionsReady === 0) {
-            eventEmitter.emit('ready');
+            eventEmitter.emit('ready', queue); // TODO: remove queue, would only be last
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/minion-army",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Microservice Framework for RabbitMQ Workers",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/minion-army",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.0",
   "description": "Microservice Framework for RabbitMQ Workers",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/minion-army",
-  "version": "1.0.3-beta.0",
+  "version": "1.0.3-beta.1",
   "description": "Microservice Framework for RabbitMQ Workers",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This fixes the issue where on project startup only the last queue name is printed in the "ready to consumer on..." message.

Tradeoff was made in correctness for backwards compatibility. Alternative is to publish a major (breaking) version with e.g. `eventEmitter.emit('ready', workerNames);` which would require a change in all existing library users.