### PR TITLE
feat: exchange injection and reuse

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,29 @@ const validatorFactory = (handler, schema) => (payload, metadata) => { // eslint
     return handler(value, metadata);
 };
 
+const createExchange = (connection, workerConfig, exchangeMap) => {
+
+    if (workerConfig.exchange) {
+        return workerConfig.exchange;
+    }
+
+    // allow for global overriding of an exchange. this is for the expected use case that
+    //  any given manifest will need a single exchange
+    if (connection.exchange) {
+        return connection.exchange;
+    }
+
+    const exchangeName = workerConfig.exchangeName || workerConfig.name; // using the same fallbacks as minion lib
+    const exchangeType = workerConfig.exchangeType;
+    const exchangeMapKey = `${exchangeType}.${exchangeName}`;
+
+    if (!exchangeMap[exchangeMapKey]) {
+        exchangeMap[exchangeMapKey] = connection.rabbit[exchangeType](exchangeName);
+    }
+
+    return exchangeMap[exchangeMapKey];
+};
+
 module.exports = (_manifest) => {
 
     const { error, value: validatedManifest } = Schema.validate(_manifest);
@@ -27,13 +50,16 @@ module.exports = (_manifest) => {
 
     const manifest = {
         connection: {
-            rabbitUrl: process.env.RABBIT_URL || 'amqp://localhost'
+            rabbitUrl: process.env.RABBIT_URL || 'amqp://127.0.0.1'
         },
+        defaults: {},
         ...validatedManifest
     };
+    
+    manifest.connection.rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl);
 
     const eventEmitter = new EventEmitter();
-    const rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl);
+    const exchangeMap = {};
 
     let minionsReady = manifest.workers.length;
     const checkReady = (queue) => {
@@ -46,13 +72,15 @@ module.exports = (_manifest) => {
     const minions = manifest.workers.reduce((minionsByName, worker) => {
 
         const handlerWithValidation = validatorFactory(worker.handler, worker.validate || Joi.any());
-
-        const minion = Minion(handlerWithValidation, {
+        const workerConfig = {
             autoStart: false,
-            rabbit,
-            ...manifest.defaults || {},
+            rabbit: manifest.connection.rabbit,
+            ...manifest.defaults,
             ...worker.config
-        });
+        };
+        const exchange = createExchange(manifest.connection, workerConfig, exchangeMap);
+
+        const minion = Minion(handlerWithValidation, { ...workerConfig, exchange });
 
         minion.on('ready', checkReady);
         minion.on('message', (m, meta) => eventEmitter.emit('message', worker.config.name, m, meta));
@@ -64,8 +92,9 @@ module.exports = (_manifest) => {
     const start = () => Object.values(minions).forEach((minion) => minion.start());
 
     return Object.assign(eventEmitter, {
+        exchangeMap,
         minions,
-        rabbit,
+        rabbit: manifest.connection.rabbit,
         start
     });
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -3,9 +3,11 @@
 const Joi = require('@hapi/joi');
 
 const rabbit = Joi.object(); // TODO: validate that rabbit object complies with jackrabbit interface
+const exchange = Joi.object(); // TODO: validate that exchange object complies with jackrabbit interface
 
-const config = {
-    exchangeType: Joi.string(),
+const config = Joi.object({
+    exchange,
+    exchangeType: Joi.string().default('topic'),
     exchangeName: Joi.string(),
     name: Joi.string(),
     key: Joi.string(),
@@ -17,7 +19,7 @@ const config = {
     rabbit,
     rabbitUrl: Joi.string(),
     prefetch: Joi.number()
-};
+});
 
 const worker = {
     handler: Joi.func().required(),
@@ -28,6 +30,7 @@ const worker = {
 module.exports = Joi.object({
     connection: Joi.object({
         rabbit,
+        exchange,
         rabbitUrl: Joi.string()
     }),
     defaults: config,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/pagerinc/minion#readme",
   "dependencies": {
     "@hapi/joi": "16.x",
-    "@pager/jackrabbit": "4.x",
+    "@pager/jackrabbit": "5.x",
     "@pager/minion": "3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
- ability to inject an exchange in the configuration
- lots of work to ensure this is backwards compatible
- if no exchange is provided, it will attempt to reuse exchanges as much as possible given the configurations for each worker
- ensuring backwards compatibility and no breaking changes