### PR TITLE
feat: add nConsumers option to workers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,12 @@ module.exports = (_manifest) => {
     const eventEmitter = new EventEmitter();
     const exchangeMap = {};
 
-    let minionsReady = manifest.workers.length;
+    let minionsReady = manifest.workers.reduce((acc, worker) => {
+
+        const nConsumers = worker.config.nConsumers || 1;
+        return acc + nConsumers;
+    }, 0);
+
     const checkReady = (queue) => {
 
         if (--minionsReady === 0) {
@@ -85,11 +90,19 @@ module.exports = (_manifest) => {
         };
         const exchange = createExchange(manifest.connection, workerConfig, exchangeMap);
 
-        const minion = Minion(handlerWithValidation, { ...workerConfig, exchange });
+        const minionsArray = [];
+        const nConsumers = worker.config.nConsumers || 1;
+        for (let i = 0; i < nConsumers; ++i) {
+            const minion = Minion(handlerWithValidation, { ...workerConfig, exchange });
 
-        minion.on('ready', checkReady);
-        minion.on('message', (m, meta) => eventEmitter.emit('message', worker.config.name, m, meta));
-        minion.on('error', (e) => eventEmitter.emit('error', e));
+            minion.on('ready', checkReady);
+            minion.on('message', (m, meta) => eventEmitter.emit('message', worker.config.name, m, meta));
+            minion.on('error', (e) => eventEmitter.emit('error', e));
+
+            minionsArray.push(minion);
+        }
+
+        const minion = minionsArray[0];
 
         return Object.assign(minionsByName, { [worker.config.name]: minion });
     }, {});

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -18,7 +18,8 @@ const config = Joi.object({
     deadLetterExchange: Joi.alternatives().try(Joi.boolean().valid(false), Joi.string()),
     rabbit,
     rabbitUrl: Joi.string(),
-    prefetch: Joi.number()
+    prefetch: Joi.number(),
+    nConsumers: Joi.number()
 });
 
 const worker = {


### PR DESCRIPTION
Currently, we create a queue per event which might affect RabbitMQ performance as every queue is a resource that needs to be handled. Instead of one queue per event, we can use a topic key that would route different messages to the same queue. As all events will be routed to the same queue, is necessary to add an option to scale how many consumers per queue there exists. The default will be one, but you will be able to scale like this:

```
workers: [
  {
      handler: IntegrationEvents.handler,
      config: {
        name: 'IntegrationEventsQueue',
        key: 'integrations.#'
        nConsumers: 5
      }
    }
]
```

Now all of the events 
```
const events = {
    INTEGRATIONS_AGENTS_JOIN: 'integrations.agents.join',
    INTEGRATIONS_AGENTS_LEAVE: 'integrations.agents.leave',
    INTEGRATIONS_ENCOUNTERS_ACCEPTED: 'integrations.encounters.accepted',
    INTEGRATIONS_ENCOUNTERS_CREATED: 'integrations.encounters.created',
    INTEGRATIONS_ENCOUNTERS_ENDED: 'integrations.encounters.ended',
    INTEGRATIONS_QUEUES_TRANSFER: 'integrations.queues.transfer'
};
```

Will be routed to the `IntegrationEventsQueue` which will have 5 consumers that know how to dispatch the event handling based on the routing key.
