### PR TITLE
feat: add queueMode option

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -18,7 +18,8 @@ const config = Joi.object({
     deadLetterExchange: Joi.alternatives().try(Joi.boolean().valid(false), Joi.string()),
     rabbit,
     rabbitUrl: Joi.string(),
-    prefetch: Joi.number()
+    prefetch: Joi.number(),
+    queueMode: Joi.string()
 });
 
 const worker = {


### PR DESCRIPTION
Passing `queueMode: 'lazy'` makes queues to store messages in disk. This will be useful for replays because it will give more room before RabbitMQ blocks.