### PR TITLE
chore: update @hapi/joi to joi


### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Microservice Framework for RabbitMQ Workers
 
 ```javascript
 const Army = require('@pager/minion-army');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 // Refer to lib/schema.js to see valid options
 const manifest = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Minion = require('@pager/minion');
 const { EventEmitter } = require('events');
 const Jackrabbit = require('@pager/jackrabbit');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const Schema = require('./schema');
 
 const validatorFactory = (handler, schema) => (payload, metadata) => { // eslint-disable-line

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const rabbit = Joi.object(); // TODO: validate that rabbit object complies with jackrabbit interface
 const exchange = Joi.object(); // TODO: validate that exchange object complies with jackrabbit interface

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "homepage": "https://github.com/pagerinc/minion#readme",
   "dependencies": {
-    "@hapi/joi": "17.x",
     "@pager/jackrabbit": "5.x",
-    "@pager/minion": "3.x"
+    "@pager/minion": "3.x",
+    "joi": "^17.2.0"
   },
   "devDependencies": {
     "@hapi/eslint-config-hapi": "13.x",

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 const { EventEmitter } = require('events');
 const Test = require('ava');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const Army = require('../lib/index');
 


### PR DESCRIPTION
Update the soon-to-be-deprecated @hapi/joi package to joi per https://github.com/sideway/joi/issues/2411

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖