### PR TITLE
fix(rabbit): kill service on rabbit disconnection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,17 @@ module.exports = (_manifest) => {
         ...validatedManifest
     };
 
-    manifest.connection.rabbit = manifest.connection.rabbit || Jackrabbit(manifest.connection.rabbitUrl);
+    if (!manifest.connection.rabbit) {
+        const rabbit = Jackrabbit(manifest.connection.rabbitUrl);
+
+        rabbit.on('error', (err) => {
+
+            console.error({ err }, 'Rabbit connection error!');
+            process.exit(1);
+        });
+
+        manifest.connection.rabbit = rabbit;
+    }
 
     const eventEmitter = new EventEmitter();
     const exchangeMap = {};


### PR DESCRIPTION
- add listener for rabbit connection to check on error, to kill the process
- this will trigger a crashloop error in the k8s pod, which will make it to restart until rabbitmq is up and running