### PR TITLE
feat(ODIN-13): set NR transaction name based on worker name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const Minion = require('@pager/minion');
 const { EventEmitter } = require('events');
 const Jackrabbit = require('@pager/jackrabbit');
 const Joi = require('joi');
+const NewRelic = require('newrelic');
 const Schema = require('./schema');
 
 const validatorFactory = (handler, schema) => (payload, metadata) => { // eslint-disable-line
@@ -105,6 +106,8 @@ module.exports = (_manifest) => {
     };
 
     const start = () => Object.values(minions).forEach((minion) => minion.start());
+
+    eventEmitter.on('message', (name, _message, _meta) => NewRelic.setTransactionName(name));
 
     return Object.assign(eventEmitter, {
         exchangeMap,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "semantic-release": "21.x"
   },
   "peerDependencies": {
-    "joi": "^17.2.0"
+    "joi": "^17.2.0",
+    "newrelic": "11.x"
   },
   "renovate": {
     "extends": [


### PR DESCRIPTION
[ODIN-13]

Updates transaction naming scheme to be more meaningful. Instead of getting the default `OtherTransaction/Message/RabbitMQ/Exchange/Named/events`, we will get names that are broken out by the worker's name, like `OtherTransaction/Message/Custom/events.socker.agents.status.updated`

Tested out here https://github.com/pagerinc/socker/pull/1366 / https://onenr.io/0ZQWmXBLBRW

[ODIN-13]: https://pagerinc.atlassian.net/browse/ODIN-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ